### PR TITLE
Implement Metadata extraction service

### DIFF
--- a/src/services/asset_service/tests/conftest.py
+++ b/src/services/asset_service/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from services.asset_service.src.main import app
+
+@pytest.fixture
+def client():
+    return TestClient(app)

--- a/src/services/asset_service/tests/test_asset_service_routes.py
+++ b/src/services/asset_service/tests/test_asset_service_routes.py
@@ -1,0 +1,60 @@
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from services.asset_service.src.main import app
+from services.asset_service.src.database.crud.asset_service_crud import AssetCRUD
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+VALID_ASSET = {
+    "id": "123",
+    "user_id": "u1",
+    "filename": "f.jpg",
+    "content_type": "image/jpeg",
+    "file_type": "image",
+    "url": "http://s3/bucket/f.jpg"
+}
+
+async def fake_get_by_id(asset_id):
+    return VALID_ASSET
+
+@ pytest.mark.asyncio
+async def test_get_asset_by_id(monkeypatch, client):
+    monkeypatch.setattr(AssetCRUD, "get_by_id", fake_get_by_id)
+    response = client.get(f"/assets?asset_id={VALID_ASSET['id']}")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert isinstance(data, list)
+    assert data[0] == VALID_ASSET
+
+@ pytest.mark.asyncio
+async def test_get_asset_invalid_id_format(client):
+    response = client.get("/assets?asset_id=invalid-id")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+def test_get_asset_by_id(monkeypatch, client):
+    # Prepare fake asset
+    fake_asset = {
+        "id": "123",
+        "user_id": "u1",
+        "filename": "file.jpg",
+        "content_type": "image/jpeg",
+        "file_type": "image",
+        "url": "http://s3/test/file.jpg"
+    }
+    async def fake_get_by_id(asset_id):
+        return fake_asset
+
+    monkeypatch.setattr(AssetCRUD, "get_by_id", fake_get_by_id)
+    res = client.get(f"/assets?asset_id={fake_asset['id']}")
+    assert res.status_code == status.HTTP_200_OK
+    data = res.json()
+    assert isinstance(data, list)
+    assert data[0] == fake_asset
+
+def test_get_asset_invalid_id_format(client):
+    res = client.get("/assets?asset_id=not-an-objectid")
+    assert res.status_code == status.HTTP_400_BAD_REQUEST

--- a/src/services/llm_orchestration_service/src/routes/llm.py
+++ b/src/services/llm_orchestration_service/src/routes/llm.py
@@ -102,9 +102,9 @@ async def metadata_extraction_endpoint(service_name: str = "metadata_extraction"
         logger.warning("File name not provided in metadata_extraction_endpoint.")
         raise HTTPException(status_code=400, detail="File name is required.")
     try:
-        result = await services.extract_textual_metadata_from_file(file=file, service_name=service_name)
-        # TODO: Potentially parse `result` if it's expected to be JSON and re-serialize for consistency or validation.
-        return LLMServiceResponse(result=result)
+        raw = await services.extract_textual_metadata_from_file(file=file, service_name=service_name)
+        # wrap raw metadata string into an envelope with description field
+        return LLMServiceResponse(result={"description": raw})
     except ConfigurationException as e:
         logger.error(f"Configuration error in /metadata for service '{service_name}': {e}")
         raise HTTPException(status_code=400, detail=f"Configuration error: {e}")

--- a/src/services/llm_orchestration_service/tests/conftest.py
+++ b/src/services/llm_orchestration_service/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from fastapi.testclient import TestClient
+from services.llm_orchestration_service.src.main import app
+
+@pytest.fixture
+def client():
+    return TestClient(app)

--- a/src/services/llm_orchestration_service/tests/test_llm_metadata.py
+++ b/src/services/llm_orchestration_service/tests/test_llm_metadata.py
@@ -17,7 +17,7 @@ def stub_extract(monkeypatch):
         fake_extract
     )
 
-@ pytest.mark.asyncio
+@pytest.mark.asyncio
 async def test_llm_metadata_endpoint(client):
     # Build a dummy upload file
     file_content = b"dummy"

--- a/src/services/llm_orchestration_service/tests/test_llm_metadata.py
+++ b/src/services/llm_orchestration_service/tests/test_llm_metadata.py
@@ -1,0 +1,33 @@
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+import io
+
+from services.llm_orchestration_service.src.main import app
+from services.llm_orchestration_service.src.services.metadata_extraction import extract_textual_metadata_from_file
+from services.llm_orchestration_service.src.services.metadata_extraction import image_to_text
+
+# Override the extract_textual_metadata to a simple stub
+@pytest.fixture(autouse=True)
+def stub_extract(monkeypatch):
+    async def fake_extract(file, service_name):
+        return "stub description"
+    monkeypatch.setattr(
+        'services.llm_orchestration_service.src.services.metadata_extraction.extract_textual_metadata_from_file',
+        fake_extract
+    )
+
+@ pytest.mark.asyncio
+async def test_llm_metadata_endpoint(client):
+    # Build a dummy upload file
+    file_content = b"dummy"
+    file = io.BytesIO(file_content)
+    # TestClient uses starlette.datastructures.UploadFile via form
+    response = client.post(
+        "/llm/metadata",
+        files={"file": ("test.jpg", file, "image/jpeg")}
+    )
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    assert "result" in body
+    assert body["result"]["description"] == "stub description"

--- a/src/services/metadata_service/requirements.txt
+++ b/src/services/metadata_service/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pydantic
+aio-pika
+httpx

--- a/src/services/metadata_service/src/core/config.py
+++ b/src/services/metadata_service/src/core/config.py
@@ -1,0 +1,14 @@
+from pydantic import BaseSettings, AnyHttpUrl
+
+
+class Settings(BaseSettings):
+    rabbitmq_url: str
+    asset_service_url: AnyHttpUrl
+    llm_orchestration_service_url: AnyHttpUrl
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()

--- a/src/services/metadata_service/src/main.py
+++ b/src/services/metadata_service/src/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+import asyncio
+import aio_pika
+from core.config import settings
+from routes.metadata_service import router, on_event
+
+app = FastAPI(title="Metadata Service")
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+@app.on_event("startup")
+async def startup():
+    # Connect to RabbitMQ and start consuming AssetUploaded events
+    connection = await aio_pika.connect_robust(settings.rabbitmq_url)
+    channel = await connection.channel()
+    queue = await channel.declare_queue("asset.uploaded", durable=True)
+    await queue.consume(on_event)
+    app.state.rabbitmq_connection = connection
+
+@app.on_event("shutdown")
+async def shutdown():
+    await app.state.rabbitmq_connection.close()
+
+app.include_router(router)

--- a/src/services/metadata_service/src/routes/metadata_service.py
+++ b/src/services/metadata_service/src/routes/metadata_service.py
@@ -1,0 +1,71 @@
+import logging
+from fastapi import APIRouter, HTTPException
+from aio_pika import IncomingMessage
+import httpx
+
+from core.config import settings
+from schemas.metadata_schema import AssetUploadedEvent, MetadataResponse
+
+logger = logging.getLogger("metadata_service.router")
+router = APIRouter()
+
+@router.post("/describe/{asset_id}", response_model=MetadataResponse)
+async def describe_asset(asset_id: str):
+    """
+    HTTP trigger to describe an asset by ID.
+    """
+    return await process_asset(asset_id)
+
+async def process_asset(asset_id: str) -> MetadataResponse:
+    """
+    Fetch asset bytes and call LLM to generate description.
+    """
+    # 1) Fetch asset metadata (to get download URL) from Asset Service
+    list_url = f"{settings.asset_service_url.rstrip('/')}/assets"
+    params = {"asset_id": asset_id}
+    async with httpx.AsyncClient() as client:
+        resp_meta = await client.get(list_url, params=params)
+        resp_meta.raise_for_status()
+        assets = resp_meta.json()
+    if not assets:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    asset_info = assets[0]
+    download_url = asset_info.get("url")
+    # 2) Download binary data
+    async with httpx.AsyncClient() as client:
+        resp_file = await client.get(download_url)
+        resp_file.raise_for_status()
+        data = resp_file.content
+
+    # TODO: handle audio, video, PDF, DOCX; for now only images
+    files = {"file": (f"{asset_id}", data, asset_info.get("content_type", "application/octet-stream"))}
+
+    # 3) Call LLM Orchestration metadata endpoint
+    async with httpx.AsyncClient() as client:
+        llm_resp = await client.post(
+            f"{settings.llm_orchestration_service_url.rstrip('/')}/llm/metadata",
+            files=files
+        )
+        llm_resp.raise_for_status()
+        payload = llm_resp.json()
+        # unwrap LLMServiceResponse wrapper
+        result = payload.get("result", payload)
+
+    description = result.get("description", "")
+    logger.info(f"Described asset {asset_id}: {description}")
+    return MetadataResponse(asset_id=asset_id, description=description)
+
+async def on_event(message: IncomingMessage):
+    """
+    RabbitMQ AssetUploaded event handler.
+    """
+    async with message.process(ignore_processed=True):
+        body = message.body.decode()
+        event = AssetUploadedEvent.parse_raw(body)
+
+        # Only process images for now
+        if event.media_type.startswith("image/"):
+            meta = await process_asset(event.asset_id)
+            logger.info(f"Processed AssetUploaded event: {meta}")
+        else:
+            logger.info(f"Skipping non-image asset {event.asset_id}")

--- a/src/services/metadata_service/src/routes/metadata_service.py
+++ b/src/services/metadata_service/src/routes/metadata_service.py
@@ -4,7 +4,7 @@ from aio_pika import IncomingMessage
 import httpx
 
 from core.config import settings
-from schemas.metadata_schema import AssetUploadedEvent, MetadataResponse
+from schemas.metadata_service_schema import AssetUploadedEvent, MetadataResponse
 
 logger = logging.getLogger("metadata_service.router")
 router = APIRouter()

--- a/src/services/metadata_service/src/schemas/metadata_service_schema.py
+++ b/src/services/metadata_service/src/schemas/metadata_service_schema.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+class AssetUploadedEvent(BaseModel):
+    asset_id: str
+    media_type: str
+
+class MetadataResponse(BaseModel):
+    asset_id: str
+    description: str

--- a/src/services/metadata_service/tests/conftest.py
+++ b/src/services/metadata_service/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from fastapi.testclient import TestClient
+from services.metadata_service.src.main import app
+
+@pytest.fixture
+def client():
+    return TestClient(app)

--- a/src/services/metadata_service/tests/test_metadata_service_routes.py
+++ b/src/services/metadata_service/tests/test_metadata_service_routes.py
@@ -1,0 +1,44 @@
+import pytest
+from fastapi import status
+import httpx
+
+def test_health(client):
+    res = client.get("/health")
+    assert res.status_code == status.HTTP_200_OK
+    assert res.json() == {"status": "ok"}
+
+def test_describe_asset(monkeypatch, client):
+    asset_id = "123"
+    dummy_bytes = b"fake-image-bytes"
+
+    # Prepare two sequential GET responses: metadata list then file content
+    class RMeta:
+        status_code = 200
+        def raise_for_status(self): pass
+        def json(self):
+            return [{"url": "http://assets.test/download/123", "content_type": "image/jpeg"}]
+
+    class RFile:
+        status_code = 200
+        content = dummy_bytes
+        def raise_for_status(self): pass
+
+    responses = [RMeta(), RFile()]
+    async def fake_get(self, url, **kwargs):
+        return responses.pop(0)
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    # Mock call to LLM Orchestration
+    async def fake_post(self, url, **kwargs):
+        class R:
+            status_code = 200
+            def raise_for_status(self): pass
+            def json(self): return {"description": "an image"}
+        return R()
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    res = client.post(f"/describe/{asset_id}")
+    assert res.status_code == status.HTTP_200_OK
+    body = res.json()
+    assert body["asset_id"] == asset_id
+    assert body["description"] == "an image"


### PR DESCRIPTION
- [x] feat(metadata): add config support for rabbitmq, asset, and llm URLs
- [x] feat(metadata): implement RabbitMQ consumer and event handler in main.py
- [x] feat(metadata): handle AssetUploaded event and fetch file from asset_service
- [x] feat(metadata): call llm_orchestration_service to interpret image files
- [x] chore(metadata): update requirements.txt with httpx and aio-pika dependencies
- [x] feat(metadata): define schemas for AssetUploadedEvent and MetadataResponse
- [x] test(metadata): add test config and fixtures in conftest.py
- [x] test(metadata): add unit tests for metadata_service image interpretation flow
- [x] test(asset): update asset_service tests to support downstream metadata usage
- [x] feat(llm): update llm_orchestration_service to accept image files via API
- [x] test(llm): scaffold tests directory for llm_orchestration_service