### PR TITLE
Metadata asset service

### DIFF
--- a/src/services/asset_service/src/database/crud/asset_service_crud.py
+++ b/src/services/asset_service/src/database/crud/asset_service_crud.py
@@ -18,3 +18,17 @@ class AssetCRUD:
     async def get_by_user_id(user_id: str) -> list[dict]:
         assets = await db.assets.find({"user_id": user_id}).to_list(length=None)
         return [asset_to_dict(asset) for asset in assets] if assets else []
+    @staticmethod
+    async def update_metadata(asset_id: str, metadata: dict) -> dict | None:
+        """
+        Update the metadata fields (e.g., description, status) for a given asset.
+        Returns the updated asset dict or None if not found.
+        """
+        result = await db.assets.update_one(
+            {"_id": ObjectId(asset_id)},
+            {"$set": metadata}
+        )
+        if result.matched_count == 0:
+            return None
+        asset = await db.assets.find_one({"_id": ObjectId(asset_id)})
+        return asset_to_dict(asset) if asset else None

--- a/src/services/asset_service/src/routes/asset_service.py
+++ b/src/services/asset_service/src/routes/asset_service.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 import boto3
 from botocore.exceptions import ClientError
 from src.utils.publisher import publish_asset
-from src.schemas.asset_service_schema import AssetCreate, AssetResponse
+from src.schemas.asset_service_schema import AssetCreate, AssetResponse, AssetMetadataUpdate
 from src.database.crud.asset_service_crud import AssetCRUD
 from src.core.config import Config
 from fastapi import Query
@@ -94,7 +94,15 @@ async def upload_asset(
         })
     return saved
 
-
+@router.patch("/assets/{asset_id}/metadata", response_model=AssetResponse)
+async def update_asset_metadata(asset_id: str, metadata: AssetMetadataUpdate):
+    """
+    Update an asset's description and processing status.
+    """
+    updated = await AssetCRUD.update_metadata(asset_id, metadata.dict())
+    if not updated:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    return updated
 
 @router.get("/assets", response_model=list[AssetResponse])
 async def get_assets(

--- a/src/services/asset_service/src/schemas/asset_service_schema.py
+++ b/src/services/asset_service/src/schemas/asset_service_schema.py
@@ -9,3 +9,9 @@ class AssetCreate(BaseModel):
 class AssetResponse(AssetCreate):
     id: str = Field(..., description="Database ID of the asset")
     url: str = Field(..., description="S3 URL to the stored file")
+    description: str | None = Field(None, description="Text description of the asset")
+    status: str | None = Field(None, description="Processing status of the asset (e.g., described)")
+
+class AssetMetadataUpdate(BaseModel):
+    description: str = Field(..., description="New description for the asset")
+    status: str = Field(..., description="New processing status for the asset")

--- a/src/services/metadata_service/pytest.ini
+++ b/src/services/metadata_service/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath = src
+testpaths = tests
+addopts = -q --disable-warnings

--- a/src/services/metadata_service/src/core/asset_client.py
+++ b/src/services/metadata_service/src/core/asset_client.py
@@ -1,0 +1,9 @@
+import httpx
+from ..schemas.asset import AssetUpdatePayload
+from .config import settings
+
+async def update_metadata(payload: AssetUpdatePayload) -> None:
+    url = f"{settings.asset_service_url}/assets/{payload.asset_id}/metadata"
+    async with httpx.AsyncClient() as client:
+        resp = await client.patch(url, json=payload.dict())
+        resp.raise_for_status()

--- a/src/services/metadata_service/src/core/rabbitmq.py
+++ b/src/services/metadata_service/src/core/rabbitmq.py
@@ -1,0 +1,20 @@
+import aio_pika, asyncio
+from .config import settings
+from ..schemas.asset import AssetReadyForIndexing
+
+connection: aio_pika.RobustConnection
+channel: aio_pika.RobustChannel
+
+async def connect() -> None:
+    global connection, channel
+    connection = await aio_pika.connect_robust(settings.rabbitmq_url)
+    channel = await connection.channel()
+    # declare exchange
+    await channel.declare_exchange("events", aio_pika.ExchangeType.TOPIC)
+
+async def publish_ready_for_indexing(evt: AssetReadyForIndexing):
+    exchange = await channel.get_exchange("events")
+    await exchange.publish(
+        aio_pika.Message(body=evt.json().encode()),
+        routing_key="asset.ready_for_indexing"
+    )

--- a/src/services/metadata_service/src/routes/worker.py
+++ b/src/services/metadata_service/src/routes/worker.py
@@ -1,15 +1,13 @@
 import json
 import logging
-from fastapi import APIRouter
 from aio_pika import IncomingMessage
 from ..core.rabbitmq import publish_ready_for_indexing
 from ..core.asset_client import update_metadata
 from ..schemas.asset import AssetUpdatePayload, AssetReadyForIndexing
 from core.llm_client import extract_description
 from ..core.rabbitmq import channel
+from shared.shared.events import QueueEventNames  # use shared constant for queue names
 
-
-router = APIRouter()
 
 async def on_message(msg: IncomingMessage):
     async with msg.process():
@@ -31,6 +29,7 @@ async def startup_consumer():
     """
     Declares the AssetUploaded queue and starts consuming messages with on_message callback.
     """
-    queue = await channel.declare_queue("asset.uploaded", durable=True)
+    # Use shared queue name instead of hardcoded string
+    queue = await channel.declare_queue(QueueEventNames.asset_upload, durable=True)
     await queue.consume(on_message)
 

--- a/src/services/metadata_service/src/routes/worker.py
+++ b/src/services/metadata_service/src/routes/worker.py
@@ -1,0 +1,36 @@
+import json
+import logging
+from fastapi import APIRouter
+from aio_pika import IncomingMessage
+from ..core.rabbitmq import publish_ready_for_indexing
+from ..core.asset_client import update_metadata
+from ..schemas.asset import AssetUpdatePayload, AssetReadyForIndexing
+from core.llm_client import extract_description
+from ..core.rabbitmq import channel
+
+
+router = APIRouter()
+
+async def on_message(msg: IncomingMessage):
+    async with msg.process():
+        data = json.loads(msg.body)
+        # 1) extract description via LLM client
+        description = await extract_description(data)
+        # 2) update asset
+        await update_metadata(AssetUpdatePayload(
+            asset_id=data["asset_id"], description=description
+        ))
+        # 3) publish ready event
+        await publish_ready_for_indexing(AssetReadyForIndexing(
+            asset_id=data["asset_id"],
+            user_id=data["user_id"],
+            description=description
+        ))
+
+async def startup_consumer():
+    """
+    Declares the AssetUploaded queue and starts consuming messages with on_message callback.
+    """
+    queue = await channel.declare_queue("asset.uploaded", durable=True)
+    await queue.consume(on_message)
+

--- a/src/services/metadata_service/src/schemas/asset.py
+++ b/src/services/metadata_service/src/schemas/asset.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, UUID4
+from datetime import datetime
+
+class AssetUpdatePayload(BaseModel):
+    asset_id: UUID4
+    description: str
+    status: str = "described"
+
+class AssetReadyForIndexing(BaseModel):
+    asset_id: UUID4
+    user_id: UUID4
+    description: str
+    timestamp: datetime = datetime.utcnow()

--- a/src/services/metadata_service/tests/conftest.py
+++ b/src/services/metadata_service/tests/conftest.py
@@ -1,6 +1,14 @@
+import sys
+import os
+
+# Ensure metadata_service/src is on sys.path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
 import pytest
 from fastapi.testclient import TestClient
-from services.metadata_service.src.main import app
+
+# Import app from main module
+from main import app
 
 @pytest.fixture
 def client():

--- a/src/services/metadata_service/tests/test_asset_client.py
+++ b/src/services/metadata_service/tests/test_asset_client.py
@@ -1,0 +1,44 @@
+# Ensure metadata_service/src is on PYTHONPATH
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+import pytest
+import httpx
+
+from core.asset_client import update_metadata
+from schemas.asset import AssetUpdatePayload
+
+class DummyResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("Error status", request=None, response=self)
+
+class DummyClientSuccess:
+    def __init__(self, *args, **kwargs):
+        pass
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def patch(self, url, json):
+        return DummyResponse(status_code=200)
+
+class DummyClientError(DummyClientSuccess):
+    async def patch(self, url, json):
+        return DummyResponse(status_code=500)
+
+@pytest.mark.asyncio
+async def test_update_metadata_success(monkeypatch):
+    monkeypatch.setattr(httpx, 'AsyncClient', DummyClientSuccess)
+    payload = AssetUpdatePayload(asset_id="1234", description="desc", status="described")
+    # Should not raise any exceptions
+    await update_metadata(payload)
+
+@pytest.mark.asyncio
+async def test_update_metadata_http_error(monkeypatch):
+    monkeypatch.setattr(httpx, 'AsyncClient', DummyClientError)
+    payload = AssetUpdatePayload(asset_id="1234", description="desc", status="described")
+    with pytest.raises(httpx.HTTPStatusError):
+        await update_metadata(payload)

--- a/src/services/metadata_service/tests/test_metadata_service_routes.py
+++ b/src/services/metadata_service/tests/test_metadata_service_routes.py
@@ -43,27 +43,20 @@ def test_describe_asset(monkeypatch, client):
     assert body["asset_id"] == asset_id
     assert body["description"] == "an image"
 
-def test_describe_asset_not_found(mock_httpx_get, client):
-    asset_id = "doesnt_exist"
+def test_describe_asset_not_found(monkeypatch, client):
+    # Simulate asset-service returning an empty list of metadata
+    class RMetaEmpty:
+        status_code = 200
         def raise_for_status(self): pass
         def json(self): return []
 
-    class RMeta:
-        status_code = 200
-        def raise_for_status(self): pass
-        def json(self):
-            return [{"url": "http://assets.test/download/123", "content_type": "image/jpeg"}]
+    async def fake_get(self, url, **kwargs):
+        return RMetaEmpty()
+    # Patch httpx.AsyncClient.get to use our fake_get
+    import httpx
+    monkeypatch.setattr(httpx.AsyncClient, 'get', fake_get)
 
-    class RFile:
-        status_code = 200
-        content = b"fake-image-bytes"
-        def raise_for_status(self): pass
-
-    def fake_get(self, url, **kwargs):
-        if "doesnt_exist" in url:
-            return RMetaEmpty()
-        return responses.pop(0)
-
-    responses = [RMeta(), RFile()]
+    asset_id = "doesnt_exist"
+    res = client.post(f"/describe/{asset_id}")
     assert res.status_code == status.HTTP_404_NOT_FOUND
     assert res.json() == {"detail": "Asset not found"}

--- a/src/services/metadata_service/tests/test_rabbitmq_publisher.py
+++ b/src/services/metadata_service/tests/test_rabbitmq_publisher.py
@@ -1,0 +1,58 @@
+import pytest
+import asyncio
+from core import rabbitmq
+from aio_pika import Message
+from schemas.asset import AssetReadyForIndexing
+
+# Dummy classes to simulate aio_pika connection, channel, and exchange
+class DummyExchange:
+    def __init__(self):
+        self.published = []
+    async def publish(self, message: Message, routing_key: str):
+        self.published.append((message, routing_key))
+
+class DummyChannel:
+    def __init__(self, exchange):
+        self._exchange = exchange
+    async def declare_exchange(self, name, type):
+        return self._exchange
+    async def get_exchange(self, name):
+        return self._exchange
+
+class DummyConnection:
+    def __init__(self, channel):
+        self._channel = channel
+    async def channel(self):
+        return self._channel
+    async def close(self):
+        pass
+
+@pytest.mark.asyncio
+async def test_publish_ready_for_indexing(monkeypatch):
+    # Setup dummy exchange and channel
+    exchange = DummyExchange()
+    channel = DummyChannel(exchange)
+    connection = DummyConnection(channel)
+
+    # Monkeypatch connect_robust and internal channel state
+    async def dummy_connect(url):
+        return connection
+    monkeypatch.setattr(rabbitmq, 'connect', lambda: dummy_connect(''))
+    # Need to call actual connect() to set rabbitmq.channel
+    # But our rabbitmq.connect() sets global channel, not via connect()
+    # So directly assign module globals
+    rabbitmq.connection = connection
+    rabbitmq.channel = channel
+
+    # Create test event
+    event = AssetReadyForIndexing(asset_id="1234", user_id="5678", description="Test")
+
+    # Publish and assert
+    await rabbitmq.publish_ready_for_indexing(event)
+    assert len(exchange.published) == 1
+    message, routing_key = exchange.published[0]
+    assert routing_key == 'asset.ready_for_indexing'
+    assert message.body == event.json().encode()
+    
+    # Clean up
+    await connection.close()


### PR DESCRIPTION
- [x] After getting the description, the metadata-extraction-service calls an internal endpoint on the asset-service to add the new description to the asset's metadata record and update its processing status.

- [x] It will then publish a new AssetReadyForIndexing event containing the asset ID, user ID and its new text description. 